### PR TITLE
Add composite primary key to followers table

### DIFF
--- a/Minitwit/Controllers/TimelineController.cs
+++ b/Minitwit/Controllers/TimelineController.cs
@@ -74,7 +74,8 @@ public class TimelineController : Controller
         }
 
         var ownUserID = HttpContext.Session.GetInt32("user_id");
-        _context.Database.ExecuteSqlRaw("INSERT INTO follower (who_id, whom_id) VALUES ({0}, {1})", ownUserID, profileUser.UserId);
+        _context.Followers.Add(new Follower { WhoId = Convert.ToInt64(ownUserID), WhomId = profileUser.UserId });
+        _context.SaveChanges();
 
         TempData.QueueFlashMessage($"You are now following \"{profileUser.Username}\"");
 
@@ -98,7 +99,8 @@ public class TimelineController : Controller
         }
 
         var ownUserID = HttpContext.Session.GetInt32("user_id");
-        _context.Database.ExecuteSqlRaw("DELETE FROM follower WHERE who_id = {0} AND whom_id = {1}", ownUserID, profileUser.UserId);
+        _context.Followers.Remove(new Follower { WhoId = Convert.ToInt64(ownUserID), WhomId = profileUser.UserId });
+        _context.SaveChanges();
 
         TempData.QueueFlashMessage($"You are no longer following \"{profileUser.Username}\"");
 

--- a/Minitwit/MinitwitContext.cs
+++ b/Minitwit/MinitwitContext.cs
@@ -28,8 +28,8 @@ public partial class MinitwitContext : DbContext
         modelBuilder.Entity<Follower>(entity =>
         {
             entity
-                .HasNoKey()
-                .ToTable("follower");
+                .ToTable("follower")
+                .HasKey(e => new { e.WhoId, e.WhomId });
 
             entity.Property(e => e.WhoId).HasColumnName("who_id");
             entity.Property(e => e.WhomId).HasColumnName("whom_id");

--- a/Minitwit/Models/Follower.cs
+++ b/Minitwit/Models/Follower.cs
@@ -5,7 +5,7 @@ namespace Minitwit.Models;
 
 public partial class Follower
 {
-    public long? WhoId { get; set; }
+    public long WhoId { get; set; }
 
-    public long? WhomId { get; set; }
+    public long WhomId { get; set; }
 }

--- a/schema.sql
+++ b/schema.sql
@@ -9,7 +9,8 @@ create table user (
 drop table if exists follower;
 create table follower (
   who_id integer,
-  whom_id integer
+  whom_id integer,
+  PRIMARY KEY (who_id, whom_id)
 );
 
 drop table if exists message;


### PR DESCRIPTION
# What was the issue?
The issue was that the followers table were missing primary keys in order for the Entity Framework to register changes to specific entities. 

## How did it gets fixed?
We add a primary composite key in the `schema.sql` so that the `make init` could create a new db file with the correct schema. Then we changed the `MinitwitContext.cs` file so that it now registers that there is a primary key for that table. Also in order to make this work we had to remove the possibility that the `Follower.cs` model file could set these two values to `null`