### PR TITLE
Get connectionstring from environment variables

### DIFF
--- a/Minitwit/Program.cs
+++ b/Minitwit/Program.cs
@@ -1,13 +1,21 @@
 using Minitwit;
+using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Register source of configurations
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
+    .AddEnvironmentVariables(prefix: "Minitwit_");
+
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 builder.Services.AddDbContext<MinitwitContext>(options =>
 {
-    options.UseSqlite("Data source=../test-tmp/minitwit.db");
+    options.UseSqlite(builder.Configuration.GetConnectionString("MinitwitDatabase"));
 });
 
 // Add session settings

--- a/Minitwit/appsettings.Development.json
+++ b/Minitwit/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "MinitwitDatabase": "Data source=../test-tmp/minitwit.db"
   }
 }

--- a/Minitwit/appsettings.json
+++ b/Minitwit/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "MinitwitDatabase": "Data source=../tmp/minitwit.db"
+  }
 }


### PR DESCRIPTION
This PR includes registering the configuration providers and moving the previous settings from hardcoded connectionstring to place it in the appsettings*.json files. 

> [!IMPORTANT]
> The application is now getting configurations from the appsettings. But, these settings can be overwritten by environment variables that has a prefix `Minitwit_`. 