### PR TITLE
Fix user not found and unauthorized 

### DIFF
--- a/MinitwitSimulatorAPI/Controllers/TimelineController.cs
+++ b/MinitwitSimulatorAPI/Controllers/TimelineController.cs
@@ -49,8 +49,11 @@ public class TimelineController : Controller
 
         LatestDBUtils.UpdateLatest(_context, latest);
 
-        var ownUserId = GetUser(username).UserId;
-        if (!IsLoggedIn()) { return NotFound(); } // maybe should be Unauthorized();
+        var user = GetUser(username);
+        if (user is null)
+            return NotFound();
+
+        var ownUserId = user.UserId;
 
         string otherUsername = "";
         string action = "follow";
@@ -65,12 +68,15 @@ public class TimelineController : Controller
             }
             otherUsername = dict[action];
         }
-        var otherUserId = GetUser(otherUsername).UserId;
+        var otherUser = GetUser(otherUsername);
+
+        if (otherUser is null)
+            return NotFound();
 
         if (action == "unfollow")
-            _context.Followers.Remove(new Follower { WhoId = ownUserId, WhomId = otherUserId });
+            _context.Followers.Remove(new Follower { WhoId = ownUserId, WhomId = otherUser.UserId });
         else
-            _context.Followers.Add(new Follower { WhoId = ownUserId, WhomId = otherUserId });
+            _context.Followers.Add(new Follower { WhoId = ownUserId, WhomId = otherUser.UserId });
 
         _context.SaveChanges();
 
@@ -120,7 +126,10 @@ public class TimelineController : Controller
         LatestDBUtils.UpdateLatest(_context, latest);
 
         User? profileUser = GetUser(username);
-        if (!IsLoggedIn()) { return NotFound(); } // maybe should be Unauthorized();
+        if (profileUser is null)
+            return NotFound();
+
+        if (!IsLoggedIn()) { return Forbid(); }
 
         var messages = (from message in _context.Messages
                         join user in _context.Users on message.AuthorId equals user.UserId
@@ -160,7 +169,8 @@ public class TimelineController : Controller
         LatestDBUtils.UpdateLatest(_context, latest);
 
         User? profileUser = GetUser(username);
-        if (!IsLoggedIn()) { return NotFound(); } // maybe should be Unauthorized();
+        if (profileUser is null)
+            return NotFound();
 
         var follows = (from user in _context.Users
                        join follower in _context.Followers

--- a/MinitwitSimulatorAPI/Controllers/TimelineController.cs
+++ b/MinitwitSimulatorAPI/Controllers/TimelineController.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MinitwitSimulatorAPI.Models;
@@ -54,6 +54,7 @@ public class TimelineController : Controller
             return NotFound();
 
         var ownUserId = user.UserId;
+        if (!IsLoggedIn()) { return Forbid(); }
 
         string otherUsername = "";
         string action = "follow";
@@ -94,7 +95,7 @@ public class TimelineController : Controller
 
         LatestDBUtils.UpdateLatest(_context, latest);
 
-        if (!IsLoggedIn()) { return NotFound(); } // maybe should be Unauthorized();
+        if (!IsLoggedIn()) { return Forbid(); }
         string text = "";
         using (StreamReader reader = new StreamReader(HttpContext.Request.Body))
         {
@@ -149,6 +150,8 @@ public class TimelineController : Controller
     {
         LatestDBUtils.UpdateLatest(_context, latest);
 
+        if (!IsLoggedIn()) { return Forbid(); }
+
         var messages = (from message in _context.Messages
                         join user in _context.Users on message.AuthorId equals user.UserId
                         where message.Flagged == 0
@@ -171,6 +174,8 @@ public class TimelineController : Controller
         User? profileUser = GetUser(username);
         if (profileUser is null)
             return NotFound();
+
+        if (!IsLoggedIn()) { return Forbid(); }
 
         var follows = (from user in _context.Users
                        join follower in _context.Followers

--- a/MinitwitSimulatorAPI/Controllers/TimelineController.cs
+++ b/MinitwitSimulatorAPI/Controllers/TimelineController.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MinitwitSimulatorAPI.Models;
@@ -32,7 +32,7 @@ public class TimelineController : Controller
     /// </summary>
     /// <param name="username">The username of the user.</param>
     /// <returns>A <c>User</c> object of the user with the given username.</returns>
-    private User GetUser(string username)
+    private User? GetUser(string username)
     {
         return _context.Users.SingleOrDefault(x => x.Username == username);
     }


### PR DESCRIPTION
We did not return not found or forbid in the situation where it is either not an authorized request or where the user was not found in the database