### PR TITLE
Fix last step in workflow about deploying changes 🔧 

### DIFF
--- a/remote-server/deploy.sh
+++ b/remote-server/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo $DOCKER_PASSWORD | docker login ghcr.io -u $DOCKER_USERNAME --password-stdin
+docker login ghcr.io -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 docker run --platform linux/amd64 -p 80:80 -d ghcr.io/devops2024-group-e/frontend.minitwit
 docker run --platform linux/amd64 -p 8080:8080 -d ghcr.io/devops2024-group-e/backend.minitwit

--- a/remote-server/init.sh
+++ b/remote-server/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $DOCKER_PASSWORD | docker login ghcr.io -u $DOCKER_USERNAME --password-stdin
+docker login ghcr.io -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 docker run -p 5432:5432 --name database -d ghcr.io/devops2024-group-e/database.minitwit:latest
 docker run --platform linux/amd64 -p 80:80 --name frontend -d ghcr.io/devops2024-group-e/frontend.minitwit:latest
 docker run --platform linux/amd64 -p 8080:8080 --name backend -d ghcr.io/devops2024-group-e/backend.minitwit:latest


### PR DESCRIPTION
The issue was in the way we tried to get the environment variable in order to login. According to the internet, `docker login` outputs `Error: Cannot perform an interactive login from a non TTY device` when the credentials provided with the -u and -p flags are empty. 

This PR fixes that