### PR TITLE
Add simulator API tests

### DIFF
--- a/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using static System.Net.HttpStatusCode;
+
+namespace Minitwit.Simulator.Api.Tests;
+
+public class LatestControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
+{
+
+    private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public LatestControllerTests(MinitwitSimulatorApiApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetLatest_AddOneCallWithAnIdAndGetTheLatestId_RetunsCorrectStatusAndLatestId()
+    {
+        var response = await _client.PostAsJsonAsync("/register?latest=1337", new
+        {
+            Username = "test",
+            Email = "test@test",
+            Pwd = "foo"
+        });
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(OK, response.StatusCode);
+
+        // Check that latest is updated
+        var latestResponse = await _client.GetAsync("/latest");
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(OK, latestResponse.StatusCode);
+    }
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
@@ -5,6 +5,7 @@ using static System.Net.HttpStatusCode;
 
 namespace Minitwit.Simulator.Api.Tests.Controllers;
 
+[Collection("SimulatorTest_Sequential")]
 public class LatestControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
 {
 
@@ -15,7 +16,7 @@ public class LatestControllerTests : IClassFixture<MinitwitSimulatorApiApplicati
     {
         _factory = factory;
         _client = _factory.CreateClient();
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
     }
 
     [Fact]

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -7,6 +7,7 @@ namespace Minitwit.Simulator.Api.Tests.Controllers;
 [Collection("SimulatorTest_Sequential")]
 public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
 {
+    private const string USERNAME_PREFIX = "RegisterApi";
     private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
 
@@ -18,9 +19,9 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
     }
 
     [Theory]
-    [InlineData("Registera", "a@a.a", "a", 1)]
-    [InlineData("Registerb", "b@b.b", "b", 5)]
-    [InlineData("Registerc", "c@c.c", "c", 6)]
+    [InlineData($"{USERNAME_PREFIX}a", "a@a.a", "a", 1)]
+    [InlineData($"{USERNAME_PREFIX}b", "b@b.b", "b", 5)]
+    [InlineData($"{USERNAME_PREFIX}c", "c@c.c", "c", 6)]
     public async Task Register_WithValidForm_ReturnsNoContentStatusCode(string username, string email, string password, int latest)
     {
         var response = await _client.RegisterUserAsync(username, email, password, latest: latest);
@@ -44,7 +45,7 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
             if (latestCommand is not null)
                 context.Latests.RemoveRange(latestCommand);
 
-            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith("Register")));
+            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith(USERNAME_PREFIX)));
             context.SaveChanges();
         }
     }

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -17,9 +17,9 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
     }
 
     [Theory]
-    [InlineData("a", "a@a.a", "a", 1)]
-    [InlineData("b", "b@b.b", "b", 5)]
-    [InlineData("c", "c@c.c", "c", 6)]
+    [InlineData("Registera", "a@a.a", "a", 1)]
+    [InlineData("Registerb", "b@b.b", "b", 5)]
+    [InlineData("Registerc", "c@c.c", "c", 6)]
     public async Task Register_WithValidForm_ReturnsNoContentStatusCode(string username, string email, string password, int latest)
     {
         var response = await _client.RegisterUserAsync(username, email, password, latest: latest);

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -16,15 +16,13 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
     }
 
-    [Fact]
-    public async Task Register_WithValidForm_ReturnsNoContentStatusCode()
+    [Theory]
+    [InlineData("a", "a@a.a", "a", 1)]
+    [InlineData("b", "b@b.b", "b", 5)]
+    [InlineData("c", "c@c.c", "c", 6)]
+    public async Task Register_WithValidForm_ReturnsNoContentStatusCode(string username, string email, string password, int latest)
     {
-        var response = await _client.PostAsJsonAsync("/register?latest=1", new
-        {
-            Username = "Registera",
-            Email = "a@a.a",
-            Pwd = "a"
-        });
+        var response = await _client.RegisterUserAsync(username, email, password, latest: latest);
 
         Assert.True(response.IsSuccessStatusCode);
         Assert.Equal(NoContent, response.StatusCode);
@@ -39,7 +37,8 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
             if (context is null)
                 return;
 
-            var latestCommand = context.Latests.Where(x => x.CommandId == 1);
+            var commandIds = new List<int> { 1, 5, 6 };
+            var latestCommand = context.Latests.Where(x => commandIds.Contains(x.CommandId));
 
             if (latestCommand is not null)
                 context.Latests.RemoveRange(latestCommand);

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -1,0 +1,51 @@
+using System.Net.Http.Headers;
+using MinitwitSimulatorAPI;
+using static System.Net.HttpStatusCode;
+
+namespace Minitwit.Simulator.Api.Tests.Controllers;
+
+public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
+{
+    private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public RegisterControllerTests(MinitwitSimulatorApiApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
+    }
+
+    [Fact]
+    public async Task Register_WithValidForm_ReturnsNoContentStatusCode()
+    {
+        var response = await _client.PostAsJsonAsync("/register?latest=1", new
+        {
+            Username = "Registera",
+            Email = "a@a.a",
+            Pwd = "a"
+        });
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(NoContent, response.StatusCode);
+    }
+
+    public void Dispose()
+    {
+        using (var cleanUpScope = _factory.Services.CreateScope())
+        {
+            var context = cleanUpScope.ServiceProvider.GetService<MinitwitContext>();
+
+            if (context is null)
+                return;
+
+            var latestCommand = context.Latests.Where(x => x.CommandId == 1);
+
+            if (latestCommand is not null)
+                context.Latests.RemoveRange(latestCommand);
+
+            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith("Register")));
+            context.SaveChanges();
+        }
+    }
+}

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -4,6 +4,7 @@ using static System.Net.HttpStatusCode;
 
 namespace Minitwit.Simulator.Api.Tests.Controllers;
 
+[Collection("SimulatorTest_Sequential")]
 public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
 {
     private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
@@ -13,7 +14,7 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
     {
         _factory = factory;
         _client = _factory.CreateClient();
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
     }
 
     [Theory]

--- a/Minitwit.Simulator.Api.Tests/Controllers/TimelineControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/TimelineControllerTests.cs
@@ -1,0 +1,81 @@
+using static System.Net.HttpStatusCode;
+using MinitwitSimulatorAPI;
+using MinitwitSimulatorAPI.Models;
+using System.Net.Http.Headers;
+
+namespace Minitwit.Simulator.Api.Tests.Controllers;
+
+[Collection("SimulatorTest_Sequential")]
+public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
+{
+    private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public TimelineControllerTests(MinitwitSimulatorApiApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
+
+        _client.RegisterUserAsync("Timelinea", "a@a.a", "a", 1001).Wait();
+    }
+
+    [Fact]
+    public async Task CreateMessage_MessageWithExistingUser_ReturnsNoContentStatusCode()
+    {
+        var response = await _client.CreateMessageAsync("Blub!", "Timelinea", 1002);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(NoContent, response.StatusCode);
+
+        var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
+        if (latestResponse is null)
+            Assert.Fail("Could not get latest result");
+
+        Assert.Equal(1002, latestResponse.Latest);
+    }
+
+    [Fact]
+    public async Task GetMessages_GetThe20LastMessages_ReturnOkStatusCodeAndListOfMessages()
+    {
+        await _client.CreateMessageAsync("Blub!", "Timelinea", 1003);
+        var response = await _client.GetLatestMessagesAsync(20, latest: 1004);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(OK, response.StatusCode);
+
+        var messages = await response.Content.ReadFromJsonAsync<List<MessageDTO>>();
+
+        if (messages is null)
+            Assert.Fail("'messages' is null");
+
+        bool hasMessage = messages.Any(x => x.Content == "Blub!" && x.User == "Timelinea");
+        Assert.True(hasMessage);
+
+        var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
+        if (latestResponse is null)
+            Assert.Fail("could not the latest command");
+
+        Assert.Equal(1004, latestResponse.Latest);
+    }
+
+    public void Dispose()
+    {
+        using (var cleanUpScope = _factory.Services.CreateScope())
+        {
+            var context = cleanUpScope.ServiceProvider.GetService<MinitwitContext>();
+
+            if (context is null)
+                return;
+
+            var commandIds = new List<int> { 1001, 1002, 1003 };
+            var latestCommand = context.Latests.Where(x => commandIds.Contains(x.CommandId));
+
+            if (latestCommand is not null)
+                context.Latests.RemoveRange(latestCommand);
+
+            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith("Timeline")));
+            context.SaveChanges();
+        }
+    }
+}

--- a/Minitwit.Simulator.Api.Tests/Controllers/TimelineControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/TimelineControllerTests.cs
@@ -8,6 +8,8 @@ namespace Minitwit.Simulator.Api.Tests.Controllers;
 [Collection("SimulatorTest_Sequential")]
 public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
 {
+    private const string USERNAME_PREFIX = "TimelineApi";
+
     private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
 
@@ -17,13 +19,13 @@ public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplica
         _client = _factory.CreateClient();
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", "c2ltdWxhdG9yOnN1cGVyX3NhZmUh");
 
-        _client.RegisterUserAsync("Timelinea", "a@a.a", "a", 1001).Wait();
+        _client.RegisterUserAsync($"{USERNAME_PREFIX}a", "a@a.a", "a", 1001).Wait();
     }
 
     [Fact]
     public async Task CreateMessage_MessageWithExistingUser_ReturnsNoContentStatusCode()
     {
-        var response = await _client.CreateMessageAsync("Blub!", "Timelinea", 1002);
+        var response = await _client.CreateMessageAsync("Blub!", $"{USERNAME_PREFIX}a", 1002);
 
         Assert.True(response.IsSuccessStatusCode);
         Assert.Equal(NoContent, response.StatusCode);
@@ -38,7 +40,7 @@ public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplica
     [Fact]
     public async Task GetMessages_GetThe20LastMessages_ReturnOkStatusCodeAndListOfMessages()
     {
-        await _client.CreateMessageAsync("Blub!", "Timelinea", 1003);
+        await _client.CreateMessageAsync("Blub!", $"{USERNAME_PREFIX}a", 1003);
         var response = await _client.GetLatestMessagesAsync(20, latest: 1004);
 
         Assert.True(response.IsSuccessStatusCode);
@@ -49,7 +51,7 @@ public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplica
         if (messages is null)
             Assert.Fail("'messages' is null");
 
-        bool hasMessage = messages.Any(x => x.Content == "Blub!" && x.User == "Timelinea");
+        bool hasMessage = messages.Any(x => x.Content == "Blub!" && x.User == $"{USERNAME_PREFIX}a");
         Assert.True(hasMessage);
 
         var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
@@ -57,6 +59,98 @@ public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplica
             Assert.Fail("could not the latest command");
 
         Assert.Equal(1004, latestResponse.Latest);
+    }
+
+    [Fact]
+    public async Task GetUserMessages_GetThe20LastMessages_ReturnOkStatusCodeAndListOfMessages()
+    {
+        await _client.CreateMessageAsync("Blub!", $"{USERNAME_PREFIX}a", 1005);
+        var response = await _client.GetLatestUserMessagesAsync($"{USERNAME_PREFIX}a", 20, latest: 1006);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(OK, response.StatusCode);
+
+        var messages = await response.Content.ReadFromJsonAsync<List<MessageDTO>>();
+
+        if (messages is null)
+            Assert.Fail("'messages' is null");
+
+        bool hasMessage = messages.Any(x => x.Content == "Blub!" && x.User == $"{USERNAME_PREFIX}a");
+        Assert.True(hasMessage);
+
+        var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
+        if (latestResponse is null)
+            Assert.Fail("could not the latest command");
+
+        Assert.Equal(1006, latestResponse.Latest);
+    }
+
+    [Fact]
+    public async Task FollowUser_FollowsUserGetMessages_ReturnPositiveCodesAndFollowsUser()
+    {
+
+        _client.RegisterUserAsync($"{USERNAME_PREFIX}b", "b@a.a", "b", 1007).Wait();
+        _client.RegisterUserAsync($"{USERNAME_PREFIX}c", "c@a.a", "c", 1008).Wait();
+
+        // A follows b and c
+        var followResponse = await _client.FollowUserAsync($"{USERNAME_PREFIX}a", $"{USERNAME_PREFIX}b", 1009);
+
+        Assert.True(followResponse.IsSuccessStatusCode);
+        Assert.Equal(NoContent, followResponse.StatusCode);
+
+        followResponse = await _client.FollowUserAsync($"{USERNAME_PREFIX}a", $"{USERNAME_PREFIX}c", 1010);
+
+        Assert.True(followResponse.IsSuccessStatusCode);
+        Assert.Equal(NoContent, followResponse.StatusCode);
+
+        // Get a list of a's followers
+        var followersResponse = await _client.GetAsync($"/fllws/{USERNAME_PREFIX}a?no=20&latest={1011}");
+
+        Assert.True(followersResponse.IsSuccessStatusCode);
+        Assert.Equal(OK, followersResponse.StatusCode);
+
+        var followers = await followersResponse.Content.ReadFromJsonAsync<FollowerDTO>();
+        if (followers is null)
+            Assert.Fail("Could not get followers");
+
+        Assert.Contains($"{USERNAME_PREFIX}b", followers.Follows);
+        Assert.Contains($"{USERNAME_PREFIX}c", followers.Follows);
+
+        var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
+        if (latestResponse is null)
+            Assert.Fail("Could not get latest response");
+
+        Assert.Equal(1011, latestResponse.Latest);
+    }
+
+    [Fact]
+    public async Task UnfollowUser_UnfollowUsersRemoveThemFromTheirList_ReturnsCorrectStatusCode()
+    {
+        await _client.RegisterUserAsync($"{USERNAME_PREFIX}b", "b@a.a", "b", 1012);
+        await _client.FollowUserAsync($"{USERNAME_PREFIX}a", $"{USERNAME_PREFIX}b", 1013);
+
+        var unfollowResponse = await _client.UnfollowUserAsync($"{USERNAME_PREFIX}a", $"{USERNAME_PREFIX}b", 1014);
+
+        Assert.True(unfollowResponse.IsSuccessStatusCode);
+        Assert.Equal(NoContent, unfollowResponse.StatusCode);
+
+        // Get a list of a's followers
+        var followersResponse = await _client.GetAsync($"/fllws/{USERNAME_PREFIX}a?no=20&latest={1015}");
+
+        Assert.True(followersResponse.IsSuccessStatusCode);
+        Assert.Equal(OK, followersResponse.StatusCode);
+
+        var followers = await followersResponse.Content.ReadFromJsonAsync<FollowerDTO>();
+        if (followers is null)
+            Assert.Fail("Could not get followers");
+
+        Assert.DoesNotContain($"{USERNAME_PREFIX}b", followers.Follows);
+
+        var latestResponse = await _client.GetFromJsonAsync<LatestDTO>("/latest");
+        if (latestResponse is null)
+            Assert.Fail("Could not get latest response");
+
+        Assert.Equal(1015, latestResponse.Latest);
     }
 
     public void Dispose()
@@ -68,13 +162,25 @@ public class TimelineControllerTests : IClassFixture<MinitwitSimulatorApiApplica
             if (context is null)
                 return;
 
-            var commandIds = new List<int> { 1001, 1002, 1003 };
+            var commandIds = new List<int> { 1001, 1002, 1003, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015 };
             var latestCommand = context.Latests.Where(x => commandIds.Contains(x.CommandId));
 
             if (latestCommand is not null)
                 context.Latests.RemoveRange(latestCommand);
 
-            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith("Timeline")));
+            var testMessages = context.Users.Join(context.Messages, x => x.UserId, x => x.AuthorId, (user, message) => new { user.Username, Message = message })
+                                            .Where(x => x.Username.StartsWith(USERNAME_PREFIX))
+                                            .Select(x => x.Message);
+
+            context.Messages.RemoveRange(testMessages);
+
+            var testFollowers = context.Users.Join(context.Followers, x => x.UserId, x => x.WhomId, (user, follower) => new { user.Username, Follower = follower })
+                                            .Where(x => x.Username.StartsWith(USERNAME_PREFIX))
+                                            .Select(x => x.Follower);
+
+            context.Followers.RemoveRange(testFollowers);
+
+            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith(USERNAME_PREFIX)));
             context.SaveChanges();
         }
     }

--- a/Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj
+++ b/Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.16" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
+++ b/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
@@ -7,12 +7,6 @@ namespace Minitwit.Simulator.Api.Tests;
 
 public class MinitwitSimulatorApiApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
 {
-
-    public MinitwitSimulatorApiApplicationFactory()
-    {
-
-    }
-
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureServices(services =>

--- a/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
+++ b/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
@@ -1,0 +1,43 @@
+using System.Data.Common;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using MinitwitSimulatorAPI;
+
+namespace Minitwit.Simulator.Api.Tests;
+
+public class MinitwitSimulatorApiApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
+{
+
+    public MinitwitSimulatorApiApplicationFactory()
+    {
+
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Remove the application registered Minitwit services
+            var dbContextDescriptor = services.SingleOrDefault(
+                d => d.ServiceType ==
+                    typeof(DbContextOptions<MinitwitContext>));
+
+            services.Remove(dbContextDescriptor);
+
+            var dbConnectionDescriptor = services.SingleOrDefault(
+                d => d.ServiceType ==
+                    typeof(DbConnection));
+
+            services.Remove(dbConnectionDescriptor);
+
+            services.AddDbContext<MinitwitContext>((container, options) =>
+            {
+                options.UseNpgsql($"Host=127.0.0.1;Port=5432;Username=minitwit-sa;Password=123;Database=minitwit");
+            });
+
+
+        });
+
+        builder.UseEnvironment("Development");
+    }
+}

--- a/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
+++ b/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
@@ -18,4 +18,10 @@ public static class MinitwtiApiHttpClientExtensions
 
     public static async Task<HttpResponseMessage> GetLatestUserMessagesAsync(this HttpClient client, string username, int messageCount, int latest)
         => await client.GetAsync($"/msgs/{username}?latest={latest}&no={messageCount}");
+
+    public static async Task<HttpResponseMessage> FollowUserAsync(this HttpClient client, string currentUser, string usernameToFollow, int latest)
+        => await client.PostAsJsonAsync($"/fllws/{currentUser}?latest={latest}", new { Follow = usernameToFollow });
+
+    public static async Task<HttpResponseMessage> UnfollowUserAsync(this HttpClient client, string currentUser, string usernameToUnFollow, int latest)
+        => await client.PostAsJsonAsync($"/fllws/{currentUser}?latest={latest}", new { Unfollow = usernameToUnFollow });
 }

--- a/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
+++ b/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
@@ -1,0 +1,21 @@
+namespace Minitwit.Simulator.Api.Tests;
+
+public static class MinitwtiApiHttpClientExtensions
+{
+    public static async Task<HttpResponseMessage> RegisterUserAsync(this HttpClient client, string username, string email, string password, int latest)
+        => await client.PostAsJsonAsync($"/register?latest={latest}", new
+        {
+            Username = username,
+            Email = email,
+            Pwd = password
+        });
+
+    public static async Task<HttpResponseMessage> CreateMessage(this HttpClient client, string content, string username, int latest)
+        => await client.PostAsJsonAsync($"/msgs/{username}?latest={latest}", new { Content = content });
+
+    public static async Task<HttpResponseMessage> GetLatestMessages(this HttpClient client, int messageCount, int latest)
+        => await client.GetAsync($"/msgs?latest={latest}&no={messageCount}");
+
+    public static async Task<HttpResponseMessage> GetLatestUserMessages(this HttpClient client, string username, int messageCount, int latest)
+        => await client.GetAsync($"/msgs/{username}?latest={latest}&no={messageCount}");
+}

--- a/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
+++ b/Minitwit.Simulator.Api.Tests/Utils/MinitwitApiHttpClientExtensions.cs
@@ -10,12 +10,12 @@ public static class MinitwtiApiHttpClientExtensions
             Pwd = password
         });
 
-    public static async Task<HttpResponseMessage> CreateMessage(this HttpClient client, string content, string username, int latest)
+    public static async Task<HttpResponseMessage> CreateMessageAsync(this HttpClient client, string content, string username, int latest)
         => await client.PostAsJsonAsync($"/msgs/{username}?latest={latest}", new { Content = content });
 
-    public static async Task<HttpResponseMessage> GetLatestMessages(this HttpClient client, int messageCount, int latest)
+    public static async Task<HttpResponseMessage> GetLatestMessagesAsync(this HttpClient client, int messageCount, int latest)
         => await client.GetAsync($"/msgs?latest={latest}&no={messageCount}");
 
-    public static async Task<HttpResponseMessage> GetLatestUserMessages(this HttpClient client, string username, int messageCount, int latest)
+    public static async Task<HttpResponseMessage> GetLatestUserMessagesAsync(this HttpClient client, string username, int messageCount, int latest)
         => await client.GetAsync($"/msgs/{username}?latest={latest}&no={messageCount}");
 }

--- a/Minitwit/Minitwit.csproj
+++ b/Minitwit/Minitwit.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Minitwit.Tests" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">

--- a/MinitwitSimulatorAPI/Controllers/LatestController.cs
+++ b/MinitwitSimulatorAPI/Controllers/LatestController.cs
@@ -30,6 +30,6 @@ public class LatestController : Controller
                        select l.CommandId).Take(1).ToList().FirstOrDefault(-1);
 
 
-        return Ok(new { Latest = content });
+        return Ok(new LatestDTO(content));
     }
 }

--- a/MinitwitSimulatorAPI/Controllers/TimelineController.cs
+++ b/MinitwitSimulatorAPI/Controllers/TimelineController.cs
@@ -136,7 +136,7 @@ public class TimelineController : Controller
                         join user in _context.Users on message.AuthorId equals user.UserId
                         where user.UserId == profileUser.UserId
                         orderby message.PubDate descending
-                        select new { Content = message.Text, message.PubDate, User = user.Username }).Take(no).ToList();
+                        select new MessageDTO(message.Text, message.PubDate.Value, user.Username)).Take(no).ToList();
 
         return Ok(messages);
     }
@@ -156,7 +156,7 @@ public class TimelineController : Controller
                         join user in _context.Users on message.AuthorId equals user.UserId
                         where message.Flagged == 0
                         orderby message.PubDate descending
-                        select new { Content = message.Text, message.PubDate, User = user.Username }).Take(no).ToList();
+                        select new MessageDTO(message.Text, message.PubDate.Value, user.Username)).Take(no).ToList();
 
         return Ok(messages);
     }

--- a/MinitwitSimulatorAPI/Controllers/TimelineController.cs
+++ b/MinitwitSimulatorAPI/Controllers/TimelineController.cs
@@ -183,6 +183,6 @@ public class TimelineController : Controller
                        where follower.WhoId == profileUser.UserId
                        select user.Username).Take(no).ToList();
 
-        return Ok(new { Follows = follows });
+        return Ok(new FollowerDTO(follows));
     }
 }

--- a/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
+++ b/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Minitwit.Simulator.Api.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.16" />

--- a/MinitwitSimulatorAPI/Models/FollowerDTO.cs
+++ b/MinitwitSimulatorAPI/Models/FollowerDTO.cs
@@ -1,0 +1,3 @@
+namespace MinitwitSimulatorAPI.Models;
+
+public record FollowerDTO(IEnumerable<string> Follows);

--- a/MinitwitSimulatorAPI/Models/LatestDTO.cs
+++ b/MinitwitSimulatorAPI/Models/LatestDTO.cs
@@ -1,0 +1,3 @@
+namespace MinitwitSimulatorAPI.Models;
+
+public record LatestDTO(int Latest);

--- a/MinitwitSimulatorAPI/Models/MessageDTO.cs
+++ b/MinitwitSimulatorAPI/Models/MessageDTO.cs
@@ -1,0 +1,3 @@
+namespace MinitwitSimulatorAPI.Models;
+
+public record MessageDTO(string Content, int PubDate, string User);

--- a/MinitwitSimulatorAPI/Program.cs
+++ b/MinitwitSimulatorAPI/Program.cs
@@ -49,3 +49,7 @@ app.UseSession();
 app.MapControllers();
 
 app.Run();
+
+// Adding this in order to make the Program class visible to our integration tests
+// as stated by the offical documentation https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-7.0
+public partial class Program { }


### PR DESCRIPTION
# What is this PR about?
This PR is about refactoring python tests to C#/dotnet. 

## What has changed?
So in order to make the tests work I had to create some DTO(Data Transfer Object) classes in order to convert the data from the apis into something that could be handled 

fixes #105 
fixes #101 
fixes #104 