### PR TITLE
Deploying to server put back

### DIFF
--- a/.github/workflows/Deployment.yaml
+++ b/.github/workflows/Deployment.yaml
@@ -12,7 +12,7 @@ on:
       - 'MinitwitSimulatorAPI/**'
 
 jobs:
-  build:
+  deployment:
     runs-on: ubuntu-latest
 
     steps:
@@ -64,11 +64,11 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
-      #- name: Deploy to server
-        # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
-      #  run: >
-      #    ssh $SSH_USER@$SSH_HOST -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
-      #    '/minitwit/deploy.sh'
-      #  env:
-      #    SSH_USER: ${{ secrets.SSH_USER }}
-      #    SSH_HOST: ${{ secrets.SSH_HOST }}
+      - name: Deploy to server
+         Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
+        run: >
+          ssh $SSH_USER@$SSH_HOST -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
+          '/minitwit/deploy.sh'
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}


### PR DESCRIPTION
Deploying the code to the server had been commented out earlier in the deployment workflow.
This PR puts it back into the workflow along with changing the name of the job run in order to display the specific action.