### PR TITLE
Add open telemetry prometheus endpoint for backend

### DIFF
--- a/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
+++ b/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">

--- a/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
+++ b/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.1">

--- a/MinitwitSimulatorAPI/Program.cs
+++ b/MinitwitSimulatorAPI/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using MinitwitSimulatorAPI.Models;
 using MinitwitSimulatorAPI;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,7 +31,8 @@ builder.Services.AddSession(options =>
 builder.Services.AddDistributedMemoryCache();
 
 builder.Services.AddOpenTelemetry()
-  .WithMetrics(b => b.AddPrometheusExporter());
+  .WithMetrics(b => b.AddAspNetCoreInstrumentation()
+                     .AddPrometheusExporter());
 
 var app = builder.Build();
 

--- a/MinitwitSimulatorAPI/Program.cs
+++ b/MinitwitSimulatorAPI/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using MinitwitSimulatorAPI.Models;
 using MinitwitSimulatorAPI;
+using OpenTelemetry.Metrics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,7 +29,12 @@ builder.Services.AddSession(options =>
 
 builder.Services.AddDistributedMemoryCache();
 
+builder.Services.AddOpenTelemetry()
+  .WithMetrics(b => b.AddPrometheusExporter());
+
 var app = builder.Build();
+
+app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
Prometheus can now acces our application and collect metrics. Simply type dotnet run and go to the /metrics endpoint where logs can be seen.