### PR TITLE
Bump version of exporter in backend to comply with metric names

### DIFF
--- a/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
+++ b/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
Since I followed a guide in the OpenTelemetry website then i installed an older version og the exporter dependency. This was an issue because the metric names did not match the ones that @Arneproductions is trying to use from a dashboard created by dotnet.