### PR TITLE
Fix integrations tests by seperating tests data

### DIFF
--- a/Minitwit.Simulator.Api.Tests/Controllers/ControllerTestCollectionDefinition.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/ControllerTestCollectionDefinition.cs
@@ -1,0 +1,8 @@
+using MinitwitSimulatorAPI;
+
+namespace Minitwit.Simulator.Api.Tests.Controllers;
+
+[CollectionDefinition(nameof(SequentialControllerTestCollectionDefinition), DisableParallelization = true)]
+public class SequentialControllerTestCollectionDefinition : ICollectionFixture<MinitwitSimulatorApiApplicationFactory<Program>>
+{
+}

--- a/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/LatestControllerTests.cs
@@ -5,8 +5,8 @@ using static System.Net.HttpStatusCode;
 
 namespace Minitwit.Simulator.Api.Tests.Controllers;
 
-[Collection("SimulatorTest_Sequential")]
-public class LatestControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
+[Collection(nameof(SequentialControllerTestCollectionDefinition))]
+public class LatestControllerTests
 {
 
     private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
@@ -37,24 +37,5 @@ public class LatestControllerTests : IClassFixture<MinitwitSimulatorApiApplicati
 
         Assert.True(response.IsSuccessStatusCode);
         Assert.Equal(OK, latestResponse.StatusCode);
-    }
-
-    public void Dispose()
-    {
-        using (var cleanUpScope = _factory.Services.CreateScope())
-        {
-            var context = cleanUpScope.ServiceProvider.GetService<MinitwitContext>();
-
-            if (context is null)
-                return;
-
-            var latestCommand = context.Latests.Where(x => x.CommandId == 1337);
-
-            if (latestCommand is not null)
-                context.Latests.RemoveRange(latestCommand);
-
-            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith("Latest")));
-            context.SaveChanges();
-        }
     }
 }

--- a/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
+++ b/Minitwit.Simulator.Api.Tests/Controllers/RegisterControllerTests.cs
@@ -4,8 +4,8 @@ using static System.Net.HttpStatusCode;
 
 namespace Minitwit.Simulator.Api.Tests.Controllers;
 
-[Collection("SimulatorTest_Sequential")]
-public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplicationFactory<Program>>, IDisposable
+[Collection(nameof(SequentialControllerTestCollectionDefinition))]
+public class RegisterControllerTests
 {
     private const string USERNAME_PREFIX = "RegisterApi";
     private readonly MinitwitSimulatorApiApplicationFactory<Program> _factory;
@@ -28,25 +28,5 @@ public class RegisterControllerTests : IClassFixture<MinitwitSimulatorApiApplica
 
         Assert.True(response.IsSuccessStatusCode);
         Assert.Equal(NoContent, response.StatusCode);
-    }
-
-    public void Dispose()
-    {
-        using (var cleanUpScope = _factory.Services.CreateScope())
-        {
-            var context = cleanUpScope.ServiceProvider.GetService<MinitwitContext>();
-
-            if (context is null)
-                return;
-
-            var commandIds = new List<int> { 1, 5, 6 };
-            var latestCommand = context.Latests.Where(x => commandIds.Contains(x.CommandId));
-
-            if (latestCommand is not null)
-                context.Latests.RemoveRange(latestCommand);
-
-            context.Users.RemoveRange(context.Users.Where(x => x.Username.StartsWith(USERNAME_PREFIX)));
-            context.SaveChanges();
-        }
     }
 }

--- a/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
+++ b/Minitwit.Simulator.Api.Tests/MinitwitSimulatorApiApplicationFactory.cs
@@ -5,10 +5,40 @@ using MinitwitSimulatorAPI;
 
 namespace Minitwit.Simulator.Api.Tests;
 
-public class MinitwitSimulatorApiApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
+public class MinitwitSimulatorApiApplicationFactory<TProgram> : WebApplicationFactory<TProgram>, IDisposable where TProgram : class
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+
+        using (var cleanupScope = this.Services.CreateScope())
+        {
+            var context = cleanupScope.ServiceProvider.GetService<MinitwitContext>();
+
+            if (context is null)
+                return ValueTask.CompletedTask;
+
+            var commandIds = new List<int> { 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015 };
+            var latestCommand = context.Latests.Where(x => commandIds.Contains(x.CommandId));
+
+            if (latestCommand is not null)
+                context.Latests.RemoveRange(latestCommand);
+
+            var testMessages = context.Messages;
+            context.Messages.RemoveRange(testMessages);
+
+            var testFollowers = context.Followers;
+
+            context.Followers.RemoveRange(testFollowers);
+
+            context.Users.RemoveRange(context.Users);
+            context.SaveChanges();
+        }
+
+        return base.DisposeAsync();
     }
 }

--- a/Minitwit.Tests/IntegrationTests/TimelineTests.cs
+++ b/Minitwit.Tests/IntegrationTests/TimelineTests.cs
@@ -7,7 +7,7 @@ namespace Minitwit.Tests.IntegrationTests;
 /// </summary>
 public class TimelineTests : IClassFixture<MinitwitApplicationFactory<Program>>, IDisposable
 {
-    private const string USERNAME_PREFIX = "Timeline";
+    private const string USERNAME_PREFIX = "TimelineUi";
 
     private readonly MinitwitApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
@@ -62,7 +62,7 @@ public class TimelineTests : IClassFixture<MinitwitApplicationFactory<Program>>,
 
         // Let bar follow foo
         var afterFollowContent = await _client.GetPageAsync($"{USERNAME_PREFIX}Foo/follow");
-        Assert.Contains("You are now following &quot;TimelineFoo&quot;", afterFollowContent);
+        Assert.Contains("You are now following &quot;TimelineUiFoo&quot;", afterFollowContent);
 
         // Foo's message should be visible in bars homepage
         barPublicTimeline = await _client.GetPageAsync();
@@ -80,7 +80,7 @@ public class TimelineTests : IClassFixture<MinitwitApplicationFactory<Program>>,
 
         // Unfollow and see that foo is no longer present in bar's timeline feed
         var unfollowResponse = await _client.GetPageAsync($"{USERNAME_PREFIX}Foo/unfollow");
-        Assert.Contains("You are no longer following &quot;TimelineFoo&quot;", unfollowResponse);
+        Assert.Contains("You are no longer following &quot;TimelineUiFoo&quot;", unfollowResponse);
 
         var timelineContent = await _client.GetPageAsync();
         Assert.DoesNotContain(messageFoo, timelineContent);


### PR DESCRIPTION
# What is this about?
This PR fixes some of the issues that we have been experiencing. The issue was that the tests in `Minitwit.Tests` deleted the data in the database. This resulted in having the data for the simulator api being deleted.

So the solution has been to change the `USERNAME_PREFIX` for the `TimelineTests`. Meanwhile we have decided to run the Simulator tests sequentially and making it delete the data when all simulator tests are done.