### PR TITLE
Bumped project versions to be current version

### DIFF
--- a/Minitwit/Minitwit.csproj
+++ b/Minitwit/Minitwit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.4.1</Version>
+    <Version>0.5.1</Version>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
+++ b/MinitwitSimulatorAPI/MinitwitSimulatorAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.4.6</Version>
+    <Version>0.5.1</Version>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
# What
The projects were not using the correct version as the scheduled releases did not run last Thursday. Thereby, the version numbers were not correct either.

This PR closes #159 