### PR TITLE
Add open telemetry prometheus endpoint for frontend :eyes: 

### DIFF
--- a/Minitwit/Minitwit.csproj
+++ b/Minitwit/Minitwit.csproj
@@ -15,6 +15,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />

--- a/Minitwit/Program.cs
+++ b/Minitwit/Program.cs
@@ -4,6 +4,9 @@ using Microsoft.EntityFrameworkCore;
 using Minitwit.Infrastructure;
 using Minitwit.Infrastructure.Repositories;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +27,9 @@ builder.Services.AddDbContext<MinitwitContext>(options =>
 builder.Services.AddScoped<IFollowerRepository,FollowerRepository>();
 builder.Services.AddScoped<IMessageRepository, MessageRepository>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddOpenTelemetry()
+  .WithMetrics(b => b.AddAspNetCoreInstrumentation()
+                     .AddPrometheusExporter());
 
 // Add session settings
 builder.Services.AddSession(options =>
@@ -34,6 +40,8 @@ builder.Services.AddSession(options =>
 });
 
 var app = builder.Build();
+
+app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## What?
For this week project work, we had to introduce a monitoring system. This PR closes issue #140 and handles adding the necessary code to the frontend project to ensure that monitoring via Prometheus is possible.

## How?
I followed @amalieboegild work for the backend (PR #151 & PR #153) in order to implement the same code for the frontend.
Prometheus is now able to access and collect metrics from the frontend.
To see it working, follow the directions in the README to run minitwit and go to the /metrics endpoint to see the logs.
