### PR TITLE
Added ssh to vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,8 +54,10 @@ Vagrant.configure("2") do |config|
     echo -e "\nSelecting Minitwit Folder as default folder when you ssh into the server...\n"
     echo "cd /config-management" >> ~/.bash_profile
 
-    echo -e "\nCreating sshkey"
+    echo -e "\nGenerating sshkey"
     ssh-keygen -f ~/.ssh/do_ssh_key -N ""
+
+    echo -e "\nSetting up "
 
     echo -e "\nVagrant setup done ..."
     SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,11 +48,11 @@ Vagrant.configure("2") do |config|
     sudo apt-get install -y vagrant-vbguest
     sudo apt-get install -y vagrant-reload
 
-    echo -e "\nInstalling Snapd"
-    sudo apt-get install -y snapd
-
-    echo -e "\nInstalling DigitalOcean command-line tool" 
-    sudo snap install doctl
+    echo -e "\nInstalling DigitalOcean command-line tool"
+    cd ~
+    wget https://github.com/digitalocean/doctl/releases/download/v1.101.0/doctl-1.101.0-linux-amd64.tar.gz
+    tar xf ~/doctl-1.101.0-linux-amd64.tar.gz
+    sudo mv ~/doctl /usr/local/bin
 
     echo -e "\nVerifying correct download - Ansible" 
     ansible --version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
 
     server.vm.provision "shell", inline: 'echo "export DIGITAL_OCEAN_TOKEN=' + "'" + ENV["DIGITAL_OCEAN_TOKEN"] + "'" + '" >> ~/.bash_profile'
     server.vm.provision "shell", inline: 'echo "export CONF_DO_TOKEN=' + "'" + ENV["CONF_DO_TOKEN"] + "'" + '" >> ~/.bash_profile'
+    server.vm.provision "shell", inline: 'echo "export DIGITAL_OCEAN_SSH_KEY_NAME=ConfigManagement" >> ~/.bash_profile'
 
     server.vm.provision "shell", inline: <<-SHELL
 
@@ -71,19 +72,19 @@ Vagrant.configure("2") do |config|
     sudo doctl auth init --access-token $CONF_DO_TOKEN
 
     echo "Checks whether the ssh-key already exists"
-    ssh_key_id=$(doctl compute ssh-key list --format "ID,Name" --no-header | grep "ConfigManagement" | awk '{print $1}')
+    ssh_key_id=$(doctl compute ssh-key list --format "ID,Name" --no-header | grep $DIGITAL_OCEAN_SSH_KEY_NAME | awk '{print $1}')
 
     if [ -n "$ssh_key_id" ]; then
-        echo "SSH key ID for 'ConfigManagement': $ssh_key_id"
+        echo "SSH key ID for $DIGITAL_OCEAN_SSH_KEY_NAME: $ssh_key_id"
         echo "Removing key"
         doctl compute ssh-key delete $ssh_key_id -f
 
     else
-        echo "SSH key with the name 'ConfigManagement' not found."
+        echo "SSH key with the name $DIGITAL_OCEAN_SSH_KEY_NAME not found."
     fi
 
     echo -e "\nAdd SSHKey to Digital Ocean"
-    doctl compute ssh-key create ConfigManagement --public-key "$(cat ~/.ssh/do_ssh_key.pub)"
+    doctl compute ssh-key create $DIGITAL_OCEAN_SSH_KEY_NAME --public-key "$(cat ~/.ssh/do_ssh_key.pub)"
 
     echo -e "\nVagrant setup done ..."
     SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,8 +35,6 @@ Vagrant.configure("2") do |config|
     sudo rm /var/lib/dpkg/lock-frontend
     sudo apt-get update
 
-    mkdir ~/.config
-
     sudo apt-get install -y software-properties-common
     sudo apt-add-repository ppa:ansible/ansible
     sudo apt-get install -y ansible

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,9 @@ Vagrant.configure("2") do |config|
     echo -e "\nSelecting Minitwit Folder as default folder when you ssh into the server...\n"
     echo "cd /config-management" >> ~/.bash_profile
 
+    echo -e "\nCreating sshkey"
+    ssh-keygen -f ~/.ssh/do_ssh_key -N ""
+
     echo -e "\nVagrant setup done ..."
     SHELL
   end


### PR DESCRIPTION
# What
We wanted to set up SSH s.t. the conf server can ssh into production servers and manage them

# How
We added support for creation of ssh keys and giving the public key to DO. Furthermore, a `Conf-management` token has been made on DO which allows the server to do send it's ssh key to DO.
![image](https://github.com/devops2024-group-e/itu-minitwit/assets/74830754/255c6053-6bac-4da9-93b5-0a1adbe33474)

> [!NOTE]
> You need to have added the `CONF_DO_TOKEN` to your `.bashrc`

This PR closes #181 