### PR TITLE
Setup logging with Loki and Promtail

### DIFF
--- a/.infrastructure/monitor-server/docker-compose.yaml
+++ b/.infrastructure/monitor-server/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     image: grafana/promtail:latest
     container_name: promtail
     volumes:
-      - /var/log:/var/log
+      - /var/lib/docker/containers:/var/lib/docker/containers
       - ./promtail-config.yaml:/etc/promtail/promtail-config.yaml
     command: -config.file=/etc/promtail/promtail-config.yaml
     networks:

--- a/.infrastructure/monitor-server/docker-compose.yaml
+++ b/.infrastructure/monitor-server/docker-compose.yaml
@@ -5,6 +5,28 @@ networks:
     name: monitoring-network
 
 services:
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    container_name: loki
+    volumes:
+      - ./loki-config.yaml:/etc/loki/loki-config.yaml
+    command: -config.file=/etc/loki/loki-config.yaml
+    networks:
+      - minitwit-ops-network
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    volumes:
+      - /var/log:/var/log
+      - ./promtail-config.yaml:/etc/promtail/promtail-config.yaml
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    networks:
+      - minitwit-ops-network
+
   grafana:
     image: grafana/grafana-oss
     container_name: grafana

--- a/.infrastructure/monitor-server/loki-config.yaml
+++ b/.infrastructure/monitor-server/loki-config.yaml
@@ -1,0 +1,68 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+ingester:
+  wal:
+    enabled: true
+    dir: /tmp/wal
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /tmp/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/.infrastructure/monitor-server/loki-config.yaml
+++ b/.infrastructure/monitor-server/loki-config.yaml
@@ -1,4 +1,4 @@
-auth_enabled: false
+auth_enabled: true
 
 server:
   http_listen_port: 3100

--- a/.infrastructure/monitor-server/promtail-config.yaml
+++ b/.infrastructure/monitor-server/promtail-config.yaml
@@ -1,0 +1,19 @@
+server:
+  #http_listen_adress: 10.114.0.2
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*log

--- a/.infrastructure/remote-server/docker-compose.yaml
+++ b/.infrastructure/remote-server/docker-compose.yaml
@@ -39,3 +39,13 @@ services:
       - '5432:5432'
     volumes:
       - pgdata:/var/lib/postgresql/data
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers
+      - ./promtail-config.yaml:/etc/promtail/promtail-config.yaml
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    networks:
+      - main

--- a/.infrastructure/remote-server/promtail-config.yaml
+++ b/.infrastructure/remote-server/promtail-config.yaml
@@ -1,4 +1,5 @@
 server:
+
   http_listen_port: 9080
   grpc_listen_port: 0
 
@@ -6,7 +7,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: http://loki:3100/loki/api/v1/push
+  - url: http://64.226.117.89:3100/loki/api/v1/push
 
 scrape_configs:
 - job_name: system
@@ -14,5 +15,5 @@ scrape_configs:
   - targets:
       - localhost
     labels:
-      job: ops
+      job: web
       __path__: /var/lib/docker/containers/*/*.log


### PR DESCRIPTION
## What
We needed to set up logging where we chose to use Loki and Promtail because we already have Grafana set up.

## How
Created config files for Promtail and Loki and added them to the docker-compose file for the ops server. On the web server we added a Promtail config file and added it to the docker-compose file and connected it to Loki on the ops server. 

To see the logs you can go in to Grafana and press explore where you then specify Loki. There is two job query's varlog that is for the opt server and webserver that is for the webserver. 

This PR should close #169 and #170 