### PR TITLE
Change testing workflow to run each test project in their own job

### DIFF
--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -11,9 +11,9 @@ on:
       - 'Minitwit.Simulator.Api.Tests/**'
       - 'Minitwit.Infrastructure/**'
       - 'Minitwit.Infrastructure.Tests/**'
-  
+
 jobs:
-  IntegrationTests-LoginAndLogout:
+  Minitwit-Infrastructure-Tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,20 +24,17 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
-      
+
       - name: Install dotnet dependencies
         run: dotnet restore
-      
+
       - name: Test dotnet version
         run: dotnet --version
-     
-      - name: Set up database
-        run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
+
       - name: Test
-        run: dotnet test Minitwit.Tests/Minitwit.Tests.csproj --filter FullyQualifiedName~Minitwit.Tests.IntegrationTests.LoginAndLogoutTests
-        
-  IntegrationTests-Register:
+        run: dotnet test Minitwit.Infrastructure.Tests/Minitwit.Infrastructure.Tests.csproj
+
+  Backend-Tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -48,20 +45,20 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
-      
+
       - name: Install dotnet dependencies
         run: dotnet restore
-      
+
       - name: Test dotnet version
         run: dotnet --version
-     
+
       - name: Set up database
         run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
-      - name: Test
-        run: dotnet test Minitwit.Tests/Minitwit.Tests.csproj --filter FullyQualifiedName~Minitwit.Tests.IntegrationTests.RegisterTests
 
-  IntegrationTests-Timeline:
+      - name: Test
+        run: dotnet test Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj
+
+  Frontend-Tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -72,87 +69,15 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
-      
+
       - name: Install dotnet dependencies
         run: dotnet restore
-      
+
       - name: Test dotnet version
         run: dotnet --version
-     
+
       - name: Set up database
         run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
+
       - name: Test
-        run: dotnet test Minitwit.Tests/Minitwit.Tests.csproj --filter FullyQualifiedName~Minitwit.Tests.IntegrationTests.TimelineTests
-
-  ControllerTests-Latest:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Dotnet
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
-      
-      - name: Install dotnet dependencies
-        run: dotnet restore
-      
-      - name: Test dotnet version
-        run: dotnet --version
-     
-      - name: Set up database
-        run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
-      - name: Test
-        run: dotnet test Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj --filter FullyQualifiedName~Minitwit.Simulator.Api.Tests.Controllers.LatestControllerTests
-
-  ControllerTests-Register:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Dotnet
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
-      
-      - name: Install dotnet dependencies
-        run: dotnet restore
-      
-      - name: Test dotnet version
-        run: dotnet --version
-     
-      - name: Set up database
-        run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
-      - name: Test
-        run: dotnet test Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj --filter FullyQualifiedName~Minitwit.Simulator.Api.Tests.Controllers.RegisterControllerTests
-    
-  ControllerTests-Timeline:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Dotnet
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
-      
-      - name: Install dotnet dependencies
-        run: dotnet restore
-      
-      - name: Test dotnet version
-        run: dotnet --version
-     
-      - name: Set up database
-        run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
-      - name: Test
-        run: dotnet test Minitwit.Simulator.Api.Tests/Minitwit.Simulator.Api.Tests.csproj --filter FullyQualifiedName~Minitwit.Simulator.Api.Tests.Controllers.TimelineControllerTests
+        run: dotnet test Minitwit.Tests/Minitwit.Tests.csproj


### PR DESCRIPTION
# What is this PR about?
This PR is originated from two things:
1. An issue that you would have to add a new job in the testing workflow file for each test file that we create
2. That we do not run tests for the Infrastructure project

## What has been changed?
So previously we ran a job for each of the test files that we had in a test project. This would both create a huge setup overhead, for running a single test file, but also in development, because then you would have to remember to add a new job in the workflow that runs that particular test file or files which has been added.

So I have now made it such that we run the every test project in their own job. This will make it run every test file in that particular test project. 