### PR TITLE
Fix null reference in remove follower 

### DIFF
--- a/Minitwit.Infrastructure.Tests/Repositories/FollowerRepositoryTests.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/FollowerRepositoryTests.cs
@@ -16,10 +16,10 @@ public class FollowerRepositoryTests : IDisposable
         _context = new MinitwitContext(builder.Options);
         _context.Database.EnsureCreated();
 
-        _context.Users.Add(new User{UserId = 1, Username = "Alice", Email = "example@mail.com", PwHash = "qwerty"});
-        _context.Users.Add(new User{UserId = 2, Username = "Bob", Email = "example@mail.com", PwHash = "qwerty"});
-        _context.Users.Add(new User{UserId = 3, Username = "Charlie", Email = "example@mail.com", PwHash = "qwerty"});
-        _context.Users.Add(new User{UserId = 4, Username = "Dante", Email = "example@mail.com", PwHash = "qwerty"});
+        _context.Users.Add(new User { UserId = 1, Username = "Alice", Email = "example@mail.com", PwHash = "qwerty" });
+        _context.Users.Add(new User { UserId = 2, Username = "Bob", Email = "example@mail.com", PwHash = "qwerty" });
+        _context.Users.Add(new User { UserId = 3, Username = "Charlie", Email = "example@mail.com", PwHash = "qwerty" });
+        _context.Users.Add(new User { UserId = 4, Username = "Dante", Email = "example@mail.com", PwHash = "qwerty" });
         _context.SaveChanges();
 
         _followerRepository = new FollowerRepository(_context);
@@ -46,6 +46,18 @@ public class FollowerRepositoryTests : IDisposable
         Assert.True(result);
     }
 
+    /// <summary>
+    /// When we remove a follower relation that does not exist then it should return true because it is not present anymore anyway
+    /// </summary>
+    [Fact]
+    public void RemoveFollower_FollwerRelationDoesNotExistInDB_ReturnsTrue()
+    {
+        // Try to remove a follower relation that does not exist
+        var result = _followerRepository.RemoveFollower(10020, 1111);
+
+        Assert.True(result);
+    }
+
     [Fact]
     public void RemoveFollower_SuccesfullyRemovesFollower_ReturnsTrue()
     {
@@ -61,7 +73,7 @@ public class FollowerRepositoryTests : IDisposable
             () => Assert.True(removeResult),
             () => Assert.False(isFollowingResult)
         );
-        
+
     }
 
     [Fact]
@@ -85,7 +97,7 @@ public class FollowerRepositoryTests : IDisposable
         Assert.False(result);
     }
 
-    
+
     [Fact]
     public void GetCurrentUserFollows_SuccesfullyReturnsFollows_ReturnsUsername()
     {
@@ -96,7 +108,7 @@ public class FollowerRepositoryTests : IDisposable
         var result = _followerRepository.GetCurrentUserFollows(1, 1);
 
         //Assert
-        Assert.Equal(new List<string>{"Bob"}, result);
+        Assert.Equal(new List<string> { "Bob" }, result);
     }
 
     [Fact]
@@ -111,7 +123,7 @@ public class FollowerRepositoryTests : IDisposable
         var result = _followerRepository.GetCurrentUserFollows(1, 10);
 
         //Assert
-        Assert.Equal(new List<string>{"Bob", "Charlie", "Dante"}, result);
+        Assert.Equal(new List<string> { "Bob", "Charlie", "Dante" }, result);
     }
 
     public void Dispose()

--- a/Minitwit.Infrastructure/Repositories/FollowerRepository.cs
+++ b/Minitwit.Infrastructure/Repositories/FollowerRepository.cs
@@ -21,7 +21,8 @@ public class FollowerRepository : IFollowerRepository
         try
         {
             _context.SaveChanges();
-        } catch(Exception e)
+        }
+        catch (Exception e)
         {
             return false;
         }
@@ -31,11 +32,14 @@ public class FollowerRepository : IFollowerRepository
     public bool RemoveFollower(int whoId, int whomId)
     {
         var follower = _context.Followers.FirstOrDefault(x => x.WhoId == whoId && x.WhomId == whomId);
+        if (follower is null)
+            return true; // We return true to signal that the relation is not in the database
         _context.Followers.Remove(follower);
         try
         {
             _context.SaveChanges();
-        } catch(Exception e)
+        }
+        catch (Exception e)
         {
             return false;
         }
@@ -56,7 +60,7 @@ public class FollowerRepository : IFollowerRepository
                        on user.UserId equals follower.WhomId
                        where follower.WhoId == whoId
                        select user.Username).Take(no).ToList();
-        
+
         return follows;
     }
 }


### PR DESCRIPTION
# What was the issue?
The issue pretty well described in the linked github issue. But in short when trying to remove the follower we first fetch it from the database and the try to remove that entity. However, since that entity did not exist in the database then it returns `null` and tries to delete that null object resulting in a Null reference.

### What have i done to solve the issue?
I have added a test to see, and added a null check.