### PR TITLE
Register end point fix

### DIFF
--- a/MinitwitSimulatorAPI/Utils/PasswordHash.cs
+++ b/MinitwitSimulatorAPI/Utils/PasswordHash.cs
@@ -16,8 +16,8 @@ public static class PasswordHash
         var hashedResult = Convert.ToHexString(KeyDerivation.Pbkdf2(
                     password: password,
                     salt: salt,
-                    prf: KeyDerivationPrf.HMACSHA256,
-                    iterationCount: 600000,
+                    prf: KeyDerivationPrf.HMACSHA512,
+                    iterationCount: 100000,
                     numBytesRequested: 32));
         return $"{Convert.ToHexString(salt)}${hashedResult}";
     }


### PR DESCRIPTION
# What is this PR about?
We needed to figure out why the response endpoint is much slower than the rest.

# How?
We added stopwatches to test the API around the ´AddUserAsync´ method used in the register method.

# Findings
After testing we found that the password hash was responsible for about 1600 ms to 2000 ms of the response time when creating a new user. 

# Fixes?
In order to fix this we attempted to change the hashing algorithm. However, in broad strokes this seems to yield the somewhat same results. With the SHA512 algorithm we found that the variance in time was greater. in other words the best time with optimal iterations was lower than others. For certain passwords however, this algorithm would still yield the same 2 000 ms waits. Therefore, we have taken the liberty to reduce the hash iterations to 100 000, as this would still allow for the fast running times for certain passwords, but also decrease the average time spent hashing, by about half.

> [!WARNING]
> The iterations added in this PR are fewer that what's recommended by OWASP (Who recommend 210 000 iterations for SHA512).

This PR closes #171 