### PR TITLE
Fix integration test overlapping

### DIFF
--- a/Minitwit.Infrastructure.Tests/Repositories/FollowerRepositoryTests.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/FollowerRepositoryTests.cs
@@ -4,6 +4,7 @@ using Minitwit.Infrastructure.Models;
 
 namespace Minitwit.Infrastructure.Tests.Repositories;
 
+[Collection(nameof(RepositorySequentialTestCollectionDefinition))]
 public class FollowerRepositoryTests : IDisposable
 {
     private readonly FollowerRepository _followerRepository;

--- a/Minitwit.Infrastructure.Tests/Repositories/LatestRepositoryTests.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/LatestRepositoryTests.cs
@@ -4,6 +4,7 @@ using Minitwit.Infrastructure.Models;
 
 namespace Minitwit.Infrastructure.Tests.Repositories;
 
+[Collection(nameof(RepositorySequentialTestCollectionDefinition))]
 public class LatestRepositoryTests : IDisposable
 {
     private readonly LatestRepository _latestRepository;

--- a/Minitwit.Infrastructure.Tests/Repositories/MessageRepositoryTests.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/MessageRepositoryTests.cs
@@ -2,7 +2,10 @@ using Microsoft.EntityFrameworkCore;
 using Minitwit.Infrastructure.Repositories;
 using Minitwit.Infrastructure;
 using Minitwit.Infrastructure.Models;
+
 namespace Minitwit.Infrastructure.Tests.Repositories;
+
+[Collection(nameof(RepositorySequentialTestCollectionDefinition))]
 public class MessageRepositoryTests : IDisposable
 {
     private readonly IMessageRepository _messageRepo;

--- a/Minitwit.Infrastructure.Tests/Repositories/RepositorySequentialTestCollectionDefinition.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/RepositorySequentialTestCollectionDefinition.cs
@@ -1,0 +1,6 @@
+namespace Minitwit.Infrastructure.Tests.Repositories;
+
+[CollectionDefinition(nameof(RepositorySequentialTestCollectionDefinition), DisableParallelization = true)]
+public class RepositorySequentialTestCollectionDefinition
+{
+}

--- a/Minitwit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
+++ b/Minitwit.Infrastructure.Tests/Repositories/UserRepositoryTests.cs
@@ -3,6 +3,7 @@ using Minitwit.Infrastructure.Repositories;
 
 namespace Minitwit.Infrastructure.Tests.Repositories;
 
+[Collection(nameof(RepositorySequentialTestCollectionDefinition))]
 public class UserRepositoryTests : IDisposable
 {
 


### PR DESCRIPTION
# What is this PR about? 
This PR solves and issue found by @amalieboegild when running the workflow tests. As could be seen in #209 they seem to get the same item that is being tracked by Linq.

## How is this solved?
It is solved by creating a sequential test collection that will run all the Repository tests sequentially

fixes #209 