### PR TITLE
Added timestamp test to MessagesUITests.cs

### DIFF
--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Set up database
         run: docker compose -f docker-compose.yaml up minitwit-db -d
-      
+
       - name: Set up frontend
         run: dotnet run --project Minitwit/ &
 

--- a/Minitwit.Tests/UITests/FollowUnfollowUITests.cs
+++ b/Minitwit.Tests/UITests/FollowUnfollowUITests.cs
@@ -61,12 +61,12 @@ public class FollowUnfollowUITests : IDisposable
 
         //Assert Follow
         var flashMessage = _driver.FindElement(By.ClassName("flashes"));
-        Assert.True(flashMessage.Text.Contains("You are now following"));
+        Assert.Contains("You are now following", flashMessage.Text);
 
         _driver.Navigate().GoToUrl("http://localhost:5191");
         var body = _driver.FindElement(By.TagName("body"));
 
-        Assert.True(body.Text.Contains("Hej fra User 5"));
+        Assert.Contains("Hej fra User 5", body.Text);
 
         //Act Unfollow
         _driver.Navigate().GoToUrl("http://localhost:5191/public");
@@ -75,13 +75,13 @@ public class FollowUnfollowUITests : IDisposable
 
         //Assert Unfollow
         flashMessage = _driver.FindElement(By.ClassName("flashes"));
-        
-        Assert.True(flashMessage.Text.Contains("You are no longer following"));
+
+        Assert.Contains("You are no longer following", flashMessage.Text);
 
         _driver.Navigate().GoToUrl("http://localhost:5191");
         body = _driver.FindElement(By.TagName("body"));
 
-        Assert.False(body.Text.Contains("Hej fra User 5"));
+        Assert.DoesNotContain("Hej fra User 5", body.Text);
     }
 
     public void Dispose()

--- a/Minitwit.Tests/UITests/LoginRegisterLogoutUITests.cs
+++ b/Minitwit.Tests/UITests/LoginRegisterLogoutUITests.cs
@@ -25,17 +25,17 @@ public class LoginRegisterLogoutUITests : IDisposable
 
         IWebElement body = _driver.FindElement(By.TagName("body"));
 
-        var currentUrl = _driver.Url; 
+        var currentUrl = _driver.Url;
 
-        Assert.True(body.Text.Contains("MiniTwit"));
-        Assert.True(body.Text.Contains("sign up"));
-        Assert.True(body.Text.Contains("sign in"));
-        Assert.True(currentUrl.Contains("/public"));
+        Assert.Contains("MiniTwit", body.Text);
+        Assert.Contains("sign up", body.Text);
+        Assert.Contains("sign in", body.Text);
+        Assert.Contains("/public", currentUrl);
     }
 
     [Fact]
     public async Task NonRegisteredUserCanRegister()
-    {   
+    {
         //Arrange
         _driver.Navigate().GoToUrl("http://localhost:5191/");
 
@@ -51,7 +51,7 @@ public class LoginRegisterLogoutUITests : IDisposable
         //Assert
         IWebElement body = _driver.FindElement(By.TagName("body"));
 
-        Assert.True(body.Text.Contains("You were successfully registered and can login now"));
+        Assert.Contains("You were successfully registered and can login now", body.Text);
     }
 
     [Fact]
@@ -76,9 +76,9 @@ public class LoginRegisterLogoutUITests : IDisposable
         //Assert
         IWebElement body = _driver.FindElement(By.TagName("body"));
 
-        Assert.True(body.Text.Contains("You were logged in"));
-        Assert.True(body.Text.Contains("My Timeline"));
-        Assert.True(body.Text.Contains("This is you!"));
+        Assert.Contains("You were logged in", body.Text);
+        Assert.Contains("My Timeline", body.Text);
+        Assert.Contains("This is you!", body.Text);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class LoginRegisterLogoutUITests : IDisposable
         _driver.FindElement(By.Name("username")).SendKeys("Test User 3");
         _driver.FindElement(By.Name("password")).SendKeys("12345");
         _driver.FindElement(By.ClassName("actions")).Submit();
-        
+
         _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
 
         //Act
@@ -111,11 +111,11 @@ public class LoginRegisterLogoutUITests : IDisposable
         //Assert
         IWebElement body = _driver.FindElement(By.TagName("body"));
 
-        Assert.True(body.Text.Contains("You were logged out"));
-        Assert.True(body.Text.Contains("MiniTwit"));
-        Assert.True(body.Text.Contains("sign up"));
-        Assert.True(body.Text.Contains("sign in"));
-        Assert.True(_driver.Url.Contains("/public"));
+        Assert.Contains("You were logged out", body.Text);
+        Assert.Contains("MiniTwit", body.Text);
+        Assert.Contains("sign up", body.Text);
+        Assert.Contains("sign in", body.Text);
+        Assert.Contains("/public", _driver.Url);
     }
 
 

--- a/Minitwit.Tests/UITests/MessagesUITests.cs
+++ b/Minitwit.Tests/UITests/MessagesUITests.cs
@@ -44,17 +44,17 @@ public class MessagesUITests : IDisposable
 
         //Assert
         var flashMessage = _driver.FindElement(By.ClassName("flashes"));
-        Assert.True(flashMessage.Text.Contains("Your message was recorded"));
+        Assert.Contains("Your message was recorded", flashMessage.Text);
 
         var myTimelineBody = _driver.FindElement(By.TagName("body"));
-        Assert.True(myTimelineBody.Text.Contains("Hej fra User 6"));
-        Assert.True(myTimelineBody.Text.Contains(DateTime.Now.ToString("dd/MM/yyyy")));
+        Assert.Contains("Hej fra User 6", myTimelineBody.Text);
+        Assert.Contains(DateTime.Now.ToString("dd/MM/yyyy"), myTimelineBody.Text);
 
         _driver.Navigate().GoToUrl("http://localhost:5191/public");
         var publicTimelineBody = _driver.FindElement(By.TagName("body"));
-        Assert.True(publicTimelineBody.Text.Contains("Hej fra User 6"));
-        Assert.True(publicTimelineBody.Text.Contains("Test User 6"));
-        Assert.True(publicTimelineBody.Text.Contains(DateTime.Now.ToString("dd/MM/yyyy")));
+        Assert.Contains("Hej fra User 6", publicTimelineBody.Text);
+        Assert.Contains("Test User 6", publicTimelineBody.Text);
+        Assert.Contains(DateTime.Now.ToString("dd/MM/yyyy"), publicTimelineBody.Text);
     }
 
 

--- a/Minitwit.Tests/UITests/MessagesUITests.cs
+++ b/Minitwit.Tests/UITests/MessagesUITests.cs
@@ -48,11 +48,13 @@ public class MessagesUITests : IDisposable
 
         var myTimelineBody = _driver.FindElement(By.TagName("body"));
         Assert.True(myTimelineBody.Text.Contains("Hej fra User 6"));
+        Assert.True(myTimelineBody.Text.Contains(DateTime.Now.ToString("dd/MM/yyyy")));
 
         _driver.Navigate().GoToUrl("http://localhost:5191/public");
         var publicTimelineBody = _driver.FindElement(By.TagName("body"));
         Assert.True(publicTimelineBody.Text.Contains("Hej fra User 6"));
         Assert.True(publicTimelineBody.Text.Contains("Test User 6"));
+        Assert.True(publicTimelineBody.Text.Contains(DateTime.Now.ToString("dd/MM/yyyy")));
     }
 
 


### PR DESCRIPTION
# What?
We wanted to reflect the new feature of timestamps on messages in the UI tests.

This solves #211 

# Notice!
Several files were changed due to the pre-committer wanting different formats. The only real change is the check that the date is visible in the `MessagesUITests.cs` file