### PR TITLE
Move pre-commit to its own workflow

### DIFF
--- a/.github/workflows/Linters-and_Formatter.yaml
+++ b/.github/workflows/Linters-and_Formatter.yaml
@@ -1,0 +1,26 @@
+name: Linting and formatting check
+
+on:
+  workflow_dispatch:
+    manual: true
+  pull_request:
+
+
+jobs:
+  Pre-commit-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: install hadolint
+        run: |
+          sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          sudo chmod +x /bin/hadolint
+
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -15,7 +15,6 @@ on:
 jobs:
   Minitwit-Infrastructure-Tests:
     runs-on: ubuntu-latest
-    needs: Pre-commit-check
 
     steps:
       - name: Checkout
@@ -37,7 +36,6 @@ jobs:
 
   Backend-Tests:
     runs-on: ubuntu-latest
-    needs: Pre-commit-check
 
     steps:
       - name: Checkout
@@ -62,7 +60,6 @@ jobs:
 
   Frontend-Tests:
     runs-on: ubuntu-latest
-    needs: Pre-commit-check
 
     steps:
       - name: Checkout

--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -13,24 +13,6 @@ on:
       - 'Minitwit.Infrastructure.Tests/**'
 
 jobs:
-  Pre-commit-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Dotnet
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: install hadolint
-        run: |
-          sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
-          sudo chmod +x /bin/hadolint
-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.1
-
   Minitwit-Infrastructure-Tests:
     runs-on: ubuntu-latest
     needs: Pre-commit-check


### PR DESCRIPTION
Since we only ran linters and formatters in the testing workflow then it didn't check pull requests where our application code or tests haven't been edited. So this PR moves it to its own workflow so that we always check with pre-commit if something has changed

fixes #241 