### PR TITLE
Add frontend service discovery to swarm clusters

### DIFF
--- a/.infrastructure/configuration/roles/swarm-network/tasks/main.yml
+++ b/.infrastructure/configuration/roles/swarm-network/tasks/main.yml
@@ -27,13 +27,6 @@
     interface: eth1
     port: '9323'
 
-- name: Allow service discovery
-  community.general.ufw:
-    rule: allow
-    direction: in
-    interface: eth1
-    port: '2375'
-
 - name: Allow calling prometheus
   community.general.ufw:
     rule: allow

--- a/.infrastructure/configuration/roles/swarm/tasks/main.yml
+++ b/.infrastructure/configuration/roles/swarm/tasks/main.yml
@@ -39,3 +39,8 @@
   community.docker.docker_plugin:
     plugin_name: loki
     state: enable
+
+- name: Allow access to docker.sock
+  ansible.builtin.shell: chmod 666 /var/run/docker.sock
+  args:
+    executable: /bin/bash

--- a/.infrastructure/servers/swm-server/prometheus.yml
+++ b/.infrastructure/servers/swm-server/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
     scrape_interval: 5s
 
     dockerswarm_sd_configs:
-      - host: http://192.168.1.3:2375
+      - host: unix:///var/run/docker.sock
         role: tasks
 
     relabel_configs:
@@ -34,7 +34,7 @@ scrape_configs:
     scrape_interval: 5s
 
     dockerswarm_sd_configs:
-      - host: http://192.168.1.3:2375
+      - host: unix:///var/run/docker.sock
         role: tasks
 
     relabel_configs:

--- a/.infrastructure/servers/swm-server/prometheus.yml
+++ b/.infrastructure/servers/swm-server/prometheus.yml
@@ -28,3 +28,26 @@ scrape_configs:
       - source_labels: [__meta_dockerswarm_service_name]
         regex: minitwit_minitwit-backend
         action: keep
+
+  - job_name: 'minitwit-frontend'
+
+    scrape_interval: 5s
+
+    dockerswarm_sd_configs:
+      - host: http://192.168.1.3:2375
+        role: tasks
+
+    relabel_configs:
+      # Only keep containers that should be running.
+      - source_labels: [__meta_dockerswarm_task_desired_state]
+        regex: running
+        action: keep
+
+      - source_labels: [__meta_dockerswarm_network_name]
+        regex: minitwit-network
+        action: keep
+
+      # Only keep containers apart of the service minitwit-backend
+      - source_labels: [__meta_dockerswarm_service_name]
+        regex: minitwit_minitwit-frontend
+        action: keep


### PR DESCRIPTION
This adds the frontend to the prometheus metrics gathering. Also after our security incident, i how now figured out how to close one the ports that was initially used in the attack, by using the internal `docker.sock` which prometheus now can use to gather information of running containers