### PR TITLE
Add placement constraint for prometheus

### DIFF
--- a/.infrastructure/servers/swm-server/docker-compose.yaml
+++ b/.infrastructure/servers/swm-server/docker-compose.yaml
@@ -52,6 +52,9 @@ services:
       update_config:
         delay: 10s
         order: stop-first
+      placement:
+        constraints:
+          - node.role == manager
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
# What is this about?
After a week using the new cluster, we can see that when updating the stack `minitwit` the prometheus container sometimes moves to the the swarm worker nodes. Since prometheus uses the `docker.sock` file to perform service discovery and the manager nodes contains all the swarm information, then we need to ensure that prometheus is only deployed on the manager nodes.

## How has this been solved?
It is solved by adding a deployment constraint saying that `node.role == manager`.

fixes #246 