### PR TITLE
dependabot.yml file added

### DIFF
--- a/.github/Dependabot.yml
+++ b/.github/Dependabot.yml
@@ -5,3 +5,9 @@ updates:
       directory: "/"
       schedule:
         interval: "daily"
+    
+    # Maintain dependencies for Nuget / .NET packages
+    - package-ecosystem: "nuget"
+      directory: "/"
+      schedule:
+        interval: "daily"

--- a/.github/Dependabot.yml
+++ b/.github/Dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    # Maintain dependencies for Github Actions
+    - package-ecosystem: "github-action"
+      directory: "/"
+      schedule:
+        interval: "daily"


### PR DESCRIPTION
In this PR, Dependabot is added to our project, which automatically checks for updates to dependencies in our project.

For now, checks are only added for Github Actions and Nuget. Maybe more should be added as well, but let's get this file into the project first.

This (partly) fixes #255 (might add more checks to dependabot).