### PR TITLE
Fix Prometheus port

### DIFF
--- a/.infrastructure/configuration/roles/swarm-network/tasks/main.yml
+++ b/.infrastructure/configuration/roles/swarm-network/tasks/main.yml
@@ -30,6 +30,8 @@
 - name: Allow calling prometheus
   community.general.ufw:
     rule: allow
+    direction: in
+    interface: eth1
     port: '9090'
 
 - name: Allow swarm container network discovery


### PR DESCRIPTION
We expose port 9090 to our private network only via interface eth1 as we had earlier been doing for the other ports as well. 