### PR TITLE
Fix pre-commit dotnet format issue

### DIFF
--- a/.github/workflows/Linters-and-Formatter.yaml
+++ b/.github/workflows/Linters-and-Formatter.yaml
@@ -16,10 +16,6 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Restore Dotnet projects
-        run: |
-          dotnet restore
-
       - name: install hadolint
         run: |
           sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64

--- a/.github/workflows/Linters-and-Formatter.yaml
+++ b/.github/workflows/Linters-and-Formatter.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Restore Dotnet projects
+        run: |
+          dotnet restore Minitwit.sln
+
       - name: install hadolint
         run: |
           sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64

--- a/.github/workflows/Linters-and-Formatter.yaml
+++ b/.github/workflows/Linters-and-Formatter.yaml
@@ -16,9 +16,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Restore Dotnet projects
-        run: |
-          dotnet restore ./Minitwit.sln
+
 
       - name: install hadolint
         run: |
@@ -26,5 +24,10 @@ jobs:
           sudo chmod +x /bin/hadolint
 
       - uses: actions/checkout@v4
+
+      - name: Restore Dotnet projects
+        run: |
+          dotnet restore ./Minitwit.sln
+
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/Linters-and-Formatter.yaml
+++ b/.github/workflows/Linters-and-Formatter.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Restore Dotnet projects
         run: |
-          dotnet restore Minitwit.sln
+          dotnet restore ./Minitwit.sln
 
       - name: install hadolint
         run: |

--- a/.github/workflows/Linters-and_Formatter.yaml
+++ b/.github/workflows/Linters-and_Formatter.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Restore Dotnet projects
+        run: |
+          dotnet restore
+
       - name: install hadolint
         run: |
           sudo wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
     rev: "v8.0.453106"
     hooks:
     -   id: dotnet-format
+        args: ['--no-restore']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     rev: "v8.0.453106"
     hooks:
     -   id: dotnet-format
-        args: ['--no-restore']
+        args: ['./Minitwit.sln']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     rev: "v8.0.453106"
     hooks:
     -   id: dotnet-format
-        args: ['./Minitwit.sln']
+        args: ['--no-restore']

--- a/report/sections/lessons-learned-perspective/lessons-learned-perspective.tex
+++ b/report/sections/lessons-learned-perspective/lessons-learned-perspective.tex
@@ -23,4 +23,3 @@ After many hours of attempting to get Vagrant to work with Ansible, we found out
 We decided to cut our losses with Vagrant and search for a more suitable tool that could help us write our infrastructure as code.
 The choice fell upon Pulumi in the end.
 It was a valuable lesson to see how it made a difference when we took the time to investigate different tools and their properties so we could make an informed decision based on the knowledge of our system's needs.
-


### PR DESCRIPTION
# What is this about?
This PR tries to fix the issues that we have had with pre-commit in our `linters-and-formatters` workflow. The issue seems to be an issue when running dotnet format. Apparently it should be fixed by adding a `--no-restore` flag on `dotnet format`. 

This obviously forces us to run `dotnet restore` before using pre-commit.