### PR TITLE
Remove babel to make "Part" invisible

### DIFF
--- a/report/main.tex
+++ b/report/main.tex
@@ -18,14 +18,8 @@
 \usepackage[hidelinks=true, hypertexnames=false]{hyperref} % references in text (and clickable links)
 \usepackage{wrapfig} % wrap figures
 \usepackage{longtable} % Long tables
-\usepackage[british]{babel} % quotations
 \usepackage[outputdir=build]{minted} % Code highlight
-\usepackage[%
-left = \glqq,%
-right = \grqq,%
-leftsub = \glq,%
-rightsub = \grq%
-]{dirtytalk} % quotations
+\usepackage{dirtytalk} % quotations
 
 \graphicspath{ {./images/} }
 \addbibresource{sources.bib}
@@ -44,8 +38,9 @@ rightsub = \grq%
 \renewcommand*{\nameyeardelim}{\addcomma\space}
 
 % Make the "Part I" text invisible
-\renewcommand \thepart{}
 \renewcommand \partname{}
+\renewcommand \thepart{}
+
 
 \begin{document}
     \begin{titlepage}


### PR DESCRIPTION
# Why remove `Babel`?
`Babel`caused an issue where we could see that "Part" title of the `\part` command. Part is essential in order to keep the table of contents clean of all the sections that appear in the appendix. For that reason we figured that babel caused an issue by logging in the git log and see when the visual difference was caused. 

Luckily we do not need `Babel` we could just use the package `dirtytalk` to represent quotations.